### PR TITLE
Add missing bracket; remove a useless comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ window.$docsify = {
   subMaxLevel: 2,
   loadSidebar: true,
   disqus: 'vueDataTables',
-  search: 'auto', // default,
+  search: 'auto', // default
 
   plugins: [
     DocsifyCodefund.create(15) // change to your CodeFund property id
   ]
+}
 ```
 
 # Sample


### PR DESCRIPTION
Hi again,
This PR corrects the usage part of the readme, which was missing a bracket at the end of the example.